### PR TITLE
Add check+option for pre-WoR Expert+ kick checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,5 @@ The options are as follows:
 | `r`/`--rbpro`     | Enables checking of Pro instruments.                                            |
 | `g`/`--ghband`    | Excludes the disjoint chord check for GHWT and onward songs.                    |
 | `v`/`--vocals`    | Enables checking the vocals track for issues.                                   |
+| `x`/`--expertplus`| Enables checking for mismatches between Expert and Expert+ kicks on pre-WoR-format charts. (Note: this will assume all charts are pre-WoR-formatted) |
 | `m`/`--missing`   | Checks for certain missing tracks (vox, guitar, bass, drums, keys).             |

--- a/RipCheck/Program.cs
+++ b/RipCheck/Program.cs
@@ -20,6 +20,9 @@ namespace RipCheck
         [Option('g', "ghband", Required = false, HelpText = "Excludes the disjoint chord check for GHWT and onward songs.")]
         public bool GHBand { get; set; }
 
+        [Option('x', "expertplus", Required = false, HelpText = "Enables checking for mismatches between Expert and Expert+ kicks on pre-WoR-format charts. (Note: this will assume all charts are pre-WoR-formatted)")]
+        public bool GHExpertPlus { get; set; }
+
         [Option('v', "vocals", Required = false, HelpText = "Enables checking the vocals track for issues.")]
         public bool Vocals { get; set; }
 
@@ -51,6 +54,11 @@ namespace RipCheck
         /// Check Vocals for issues.
         /// </summary>
         public bool Vocals { get; set; }
+
+        /// <summary>
+        /// Check for mismatches between pre-WoR 2x-kick-format charts.
+        /// </summary>
+        public bool GHExpertPlus { get; set; }
 
         /// <summary>
         /// Check for missing tracks.
@@ -98,6 +106,7 @@ namespace RipCheck
                         }
                         parameters.Vocals = o.Vocals;
                         parameters.MissingTracks = o.MissingTracks;
+                        parameters.GHExpertPlus = o.GHExpertPlus;
                     }
 
                     if (directory is null)

--- a/RipCheck/Tracks/DrumsTrack/DrumsTrack.cs
+++ b/RipCheck/Tracks/DrumsTrack/DrumsTrack.cs
@@ -66,21 +66,13 @@ namespace RipCheck
             var warnings = new Warnings();
 
             var diff = notes[Difficulty.Expert];
-            IEnumerable<INote> kicks = diff.Where((note) => note.Note == (byte)DrumsFretColour.Kick);
-            IEnumerable<INote> doubleKicks = diff.Where((note) => note.Note == (byte)DrumsFretColour.DoubleKick);
+            var kicks = diff.Where((note) => note.Note == (byte)DrumsFretColour.Kick);
+            var doubleKickPositions = diff.Where((note) => note.Note == (byte)DrumsFretColour.DoubleKick)
+                .Select((note) => note.Position).ToHashSet();
 
             foreach (var kick in kicks)
             {
-                bool found = false;
-                foreach (var doubleKick in doubleKicks)
-                {
-                    if (doubleKick.Position == kick.Position)
-                    {
-                        found = true;
-                    }
-                }
-
-                if (!found)
+                if (!doubleKickPositions.Contains(kick.Position))
                 {
                     warnings.AddTimed($"Found Expert kick with no corresponding Expert+ kick on {name}", kick.Position, tempoMap);
                 }

--- a/RipCheck/Tracks/DrumsTrack/DrumsTrack.cs
+++ b/RipCheck/Tracks/DrumsTrack/DrumsTrack.cs
@@ -2,6 +2,7 @@ using Melanchall.DryWetMidi.Core;
 using Melanchall.DryWetMidi.Interaction;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace RipCheck
 {
@@ -11,6 +12,7 @@ namespace RipCheck
         private readonly TempoMap tempoMap;
         private readonly string name;
         public string Name { get { return name; } }
+        private bool checkExpertPlus = false;
 
         private readonly Warnings trackWarnings = new Warnings();
 
@@ -22,6 +24,7 @@ namespace RipCheck
         {
             name = instrument;
             tempoMap = _tempoMap;
+            checkExpertPlus = parameters.GHExpertPlus;
 
             notes.Add(Difficulty.Easy, new List<INote>());
             notes.Add(Difficulty.Medium, new List<INote>());
@@ -58,12 +61,45 @@ namespace RipCheck
             }
         }
 
+        public Warnings CheckExpertPlus()
+        {
+            var warnings = new Warnings();
+
+            var diff = notes[Difficulty.Expert];
+            IEnumerable<INote> kicks = diff.Where((note) => note.Note == (byte)DrumsFretColour.Kick);
+            IEnumerable<INote> doubleKicks = diff.Where((note) => note.Note == (byte)DrumsFretColour.DoubleKick);
+
+            foreach (var kick in kicks)
+            {
+                bool found = false;
+                foreach (var doubleKick in doubleKicks)
+                {
+                    if (doubleKick.Position == kick.Position)
+                    {
+                        found = true;
+                    }
+                }
+
+                if (!found)
+                {
+                    warnings.AddTimed($"Found Expert kick with no corresponding Expert+ kick on {name}", kick.Position, tempoMap);
+                }
+            }
+
+            return warnings;
+        }
+
         public Warnings RunChecks()
         {
             foreach (KeyValuePair<Difficulty, IList<INote>> difficulty in notes)
             {
                 trackWarnings.AddRange(CommonChecks.CheckChordSnapping(difficulty.Key, difficulty.Value, name, tempoMap));
                 trackWarnings.AddRange(CommonChecks.CheckOverlappingNotes(difficulty.Key, difficulty.Value, name, tempoMap));
+            }
+
+            if (checkExpertPlus)
+            {
+                trackWarnings.AddRange(CheckExpertPlus());
             }
 
             return trackWarnings;


### PR DESCRIPTION
This option is to assist in finding cases where Expert kicks are not present in the Expert+ kicks in GH charts pre-WoR.